### PR TITLE
Update to Spigot 1.9

### DIFF
--- a/src/com/mcplugindev/slipswhitley/sketchmap/SketchMapAPI.java
+++ b/src/com/mcplugindev/slipswhitley/sketchmap/SketchMapAPI.java
@@ -107,11 +107,6 @@ public class SketchMapAPI {
 		
 		
 		Boolean publicProtected = config.getBoolean("public-protected");
-		if(publicProtected == null) {
-			throw new SketchMapFileException("Unable to load SketchMap file \"" + file.getName() 
-					+ "\" invalid field \"public-protected\"");
-		}
-		
 		List<String> mapList = config.getStringList("map-collection");
 		if(mapList == null) {
 			throw new SketchMapFileException("Unable to load SketchMap file \"" + file.getName() 

--- a/src/com/mcplugindev/slipswhitley/sketchmap/SketchMapUtils.java
+++ b/src/com/mcplugindev/slipswhitley/sketchmap/SketchMapUtils.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Set;
 
 import javax.imageio.ImageIO;
 
@@ -16,6 +17,7 @@ import net.milkbowl.vault.permission.Permission;
 
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.command.ConsoleCommandSender;
@@ -124,9 +126,8 @@ public class SketchMapUtils {
 		return Bukkit.createMap(getDefaultWorld());
 	}
 	
-	@SuppressWarnings("deprecation")
 	public static Block getTargetBlock(Player player, int i) {
-		return player.getTargetBlock(null, i);
+		return player.getTargetBlock((Set<Material>) null, i);
 	}
 	
 	

--- a/src/com/mcplugindev/slipswhitley/sketchmap/listener/PlayerListener.java
+++ b/src/com/mcplugindev/slipswhitley/sketchmap/listener/PlayerListener.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
@@ -19,8 +20,11 @@ public class PlayerListener implements Listener {
 			return;
 		}
 		
+		// 1.9 - Only use main hand
+		if (event.getHand() != EquipmentSlot.HAND) return;
+		
 		ItemFrame iFrame = (ItemFrame) event.getRightClicked();
-		ItemStack iHand = event.getPlayer().getItemInHand();
+		ItemStack iHand = event.getPlayer().getInventory().getItemInMainHand();
 		
 		if(iHand.getType() != Material.MAP) {
 			return;
@@ -58,12 +62,11 @@ public class PlayerListener implements Listener {
 		}
 		
 		if(iHand.getAmount() == 1) {
-			player.getInventory().setItemInHand(new ItemStack(Material.AIR));
+			player.getInventory().setItemInMainHand(new ItemStack(Material.AIR));
 			return;
 		}
 		
 		iHand.setAmount(iHand.getAmount() - 1);
-		
-		
+
 	}
 }


### PR DESCRIPTION
1. Removed some dead code. Don't know why you use Boolean instead of boolean... I will just leave this like that for now.
2. Updated getTargetBlock() method to a non-deprecated one.
3. Make sure PlayerInteractEvent (with blocks) will only fire once by limiting checks on main hand only, due to duel wielding may cause that event to fire twice. This will make the plugin only work for 1.9 or later.

And I didn't change anything else.

Another thing that I noticed JPEG images would not be saved (in any previous plugin versions). I do not know how to fix this. Maybe you can look into this later.
